### PR TITLE
Specifying indent size when beautifying code.

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,6 +85,7 @@ Where
 * `code` is a `String` containing the code to be processed.
 * `options` is a key/value hash. Options include: `engine` (the engine
   to use), `level` (Level of minification. The lower, the less minified.), and `log` (A `Function` for outputting all debug information. I generally use `require('sys').debug`).
+  If you're beautifying code, you can also set the `indent_size` option (A number specifying how many spaces count for a single level of indentation).
 * `callback` is a `Function` to be called once the code is returned from the engine. It's passed back in the format `callback(error, code);`
 
 Node that a callback is required because some methods (read: gcc) require asynchronous calls. In order to support this sort of engine, all code comes from callbacks. A good example may be

--- a/lib/beautifiers/js-beautify.js
+++ b/lib/beautifiers/js-beautify.js
@@ -10,7 +10,11 @@ exports = module.exports = function jsBeautify (code, options, cb) {
     jsb = require("beautifyjs").js_beautify;
     log("Running js-beautify");
     try {
-        code = jsb(code);
+        if (Object.prototype.hasOwnProperty.call(options, 'indent_size')) {
+            code = jsb(code, {"indent_size" : options.indent_size});
+        } else {
+            code = jsb(code);
+        }
         log("Finished beautifying code.");
     } catch (e) {
         cb(e);


### PR DESCRIPTION
Modified js-beautify.js and README.md.

jsBeautify allows you to set an 'indent_size' property so you're not locked into 4 spaces for indentation when beautifying code.  This PR exposes that option to the user.
